### PR TITLE
chore(winget): add workflow to auto-submit new versions to winget-pkgs

### DIFF
--- a/.github/workflows/winget-submit.yml
+++ b/.github/workflows/winget-submit.yml
@@ -5,6 +5,9 @@ on:
     workflows: ["Release"]
     types: [completed]
 
+permissions:
+  contents: read
+
 jobs:
   submit:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}

--- a/.github/workflows/winget-submit.yml
+++ b/.github/workflows/winget-submit.yml
@@ -1,0 +1,39 @@
+name: Submit to Winget
+
+on:
+  workflow_run:
+    workflows: ["Release"]
+    types: [completed]
+
+jobs:
+  submit:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: windows-latest
+    steps:
+      - name: Get latest release version
+        id: release
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          $tag     = gh release list --limit 1 --json tagName --jq '.[0].tagName'
+          $version = $tag -replace '^v', ''
+          "tag=$tag"         >> $env:GITHUB_OUTPUT
+          "version=$version" >> $env:GITHUB_OUTPUT
+
+      - name: Install wingetcreate
+        shell: pwsh
+        run: Invoke-WebRequest -Uri "https://aka.ms/wingetcreate/latest" -OutFile wingetcreate.exe
+
+      - name: Submit manifest to winget-pkgs
+        shell: pwsh
+        env:
+          WINGET_TOKEN: ${{ secrets.WINGET_TOKEN }}
+        run: |
+          $v   = "${{ steps.release.outputs.version }}"
+          $url = "https://github.com/dvalfrid/rigstats/releases/download/v${v}/RIGStats_${v}_x64-setup.exe"
+          .\wingetcreate.exe update Codeby.RIGStats `
+            --version $v `
+            --urls "$url|x64|machine" `
+            --token $env:WINGET_TOKEN `
+            --submit


### PR DESCRIPTION
Triggers after the Release workflow completes, fetches the latest release tag, and runs wingetcreate update --submit to push the updated manifest to dvalfrid/winget-pkgs and open a PR against microsoft/winget-pkgs automatically.

Requires WINGET_TOKEN secret (classic PAT, public_repo scope).