### PR TITLE
fix(winget): pass --repo to gh release list in submit workflow

### DIFF
--- a/.github/workflows/winget-submit.yml
+++ b/.github/workflows/winget-submit.yml
@@ -19,7 +19,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          $tag     = gh release list --limit 1 --json tagName --jq '.[0].tagName'
+          $tag     = gh release list --repo ${{ github.repository }} --limit 1 --json tagName --jq '.[0].tagName'
           $version = $tag -replace '^v', ''
           "tag=$tag"         >> $env:GITHUB_OUTPUT
           "version=$version" >> $env:GITHUB_OUTPUT


### PR DESCRIPTION
## Summary
- `winget-submit.yml` failed on the first real run: the job never checks out the repo, so `gh release list` can't infer owner/repo from git and errors with "not a git repository".
- Pass `--repo ${{ github.repository }}` explicitly instead of adding a full checkout step that's otherwise unused.

## Test plan
- [ ] Merge, then re-trigger `release.yml` for an existing tag and confirm `winget-submit.yml` succeeds and opens a PR against microsoft/winget-pkgs