### PR TITLE
fix(winget): skip submission when an update PR is already open

### DIFF
--- a/.github/workflows/winget-submit.yml
+++ b/.github/workflows/winget-submit.yml
@@ -24,11 +24,25 @@ jobs:
           "tag=$tag"         >> $env:GITHUB_OUTPUT
           "version=$version" >> $env:GITHUB_OUTPUT
 
+      - name: Check for an open winget-pkgs PR
+        id: existing-pr
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          $openPr = gh pr list --repo microsoft/winget-pkgs --search "Codeby.RIGStats in:title" --state open --json url --jq '.[0].url'
+          if ($openPr) {
+            Write-Host "Skipping submission — an update PR is already open: $openPr"
+          }
+          "skip=$(if ($openPr) { 'true' } else { 'false' })" >> $env:GITHUB_OUTPUT
+
       - name: Install wingetcreate
+        if: steps.existing-pr.outputs.skip != 'true'
         shell: pwsh
         run: Invoke-WebRequest -Uri "https://aka.ms/wingetcreate/latest" -OutFile wingetcreate.exe
 
       - name: Submit manifest to winget-pkgs
+        if: steps.existing-pr.outputs.skip != 'true'
         shell: pwsh
         env:
           WINGET_TOKEN: ${{ secrets.WINGET_TOKEN }}


### PR DESCRIPTION
## Summary
- `winget-submit.yml` fires unconditionally after every release, which can stack multiple open PRs against `microsoft/winget-pkgs` for the same package if releases ship faster than moderators can review them — extra manual burden on volunteer moderators (see microsoft/winget-pkgs#333536 for the backlog problem this causes at scale).
- Added a check before the `wingetcreate` submit step: if an open PR titled `Codeby.RIGStats` already exists in `microsoft/winget-pkgs`, skip the run entirely. The next release's run will pick up the latest version once the open PR merges.

## Test plan
- [ ] Merge, then verify a future release run either submits normally (no open PR) or logs "Skipping submission" and exits cleanly (open PR present)