### PR TITLE
docs(install): document winget as an installation option

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,13 @@ RIGStats is a Windows hardware-monitor dashboard built with egui — a native Ru
 
 <img src="assets/rigStats.png" width="260" alt="Main Dashboard">
 
+## Installation
+
+- **winget:** `winget install Codeby.RIGStats`
+- **Direct download:** grab the latest installer from the [Releases page](https://github.com/dvalfrid/rigstats/releases/latest)
+
+Both install the same signed NSIS installer, which also registers the sensor sidecar as a Windows Service. See [rigstats.app](https://rigstats.app/#download) for requirements and first-run guidance.
+
 ## Repository Layout
 
 | Path | Contents |

--- a/website/index.html
+++ b/website/index.html
@@ -566,6 +566,7 @@
             Download latest release
           </a>
           <p class="download-note">All versions available on the <a href="https://github.com/dvalfrid/rigstats/releases" target="_blank" rel="noopener">GitHub Releases page</a>.</p>
+          <p class="download-note">Or install via winget: <code>winget install Codeby.RIGStats</code></p>
         </div>
 
       </div>


### PR DESCRIPTION
## Summary
- RIGStats is now published on winget as `Codeby.RIGStats` (#139).
- Add it as an install method next to the direct `.exe` download: a short `## Installation` section in the README, and a line in the website's Download & Install CTA.

## Test plan
- [x] Served `website/index.html` locally and confirmed the new line renders in the existing `<code>` pill style